### PR TITLE
up to 2.8.4, removed obsolete chains

### DIFF
--- a/config/chains_config_default.json
+++ b/config/chains_config_default.json
@@ -65,22 +65,6 @@
     "maxBlockRange": 1000
   },
   {
-    "chainId": 250,
-    "name": "FANTOM",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 40423955,
-    "providers": [
-      {
-        "provider": "TODO: set your RPC",
-        "user": "",
-        "password": ""
-      }
-    ],
-    "interval": 10000,
-    "blockConfirmation": 12,
-    "maxBlockRange": 1000
-  },
-  {
     "chainId": 59144,
     "name": "Linea",
     "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
@@ -133,125 +117,6 @@
     "maxBlockRange": 0
   },
   {
-    "chainId": 100000001,
-    "name": "NEON",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 246119833,
-    "providers": [
-      {
-        "provider": "https://neon-proxy-mainnet.solana.p2p.org"
-      },
-      {
-        "provider": "https://neon-mainnet.everstake.one"
-      }
-    ],
-    "interval": 10000,
-    "blockConfirmation": 32,
-    "maxBlockRange": 100000
-  },
-  {
-    "chainId": 100000002,
-    "name": "Gnosis",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 33544534,
-    "providers": [
-      {
-        "provider": "https://rpc.eu-central-2.gateway.fm/v4/gnosis/non-archival/mainnet"
-      }
-    ],
-    "interval": 10000,
-    "blockConfirmation": 12,
-    "maxBlockRange": 5000
-  },
-  {
-    "chainId": 100000004,
-    "name": "Metis",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 16824219,
-    "providers": [
-      {
-        "provider": "https://andromeda.metis.io/?owner=1088"
-      }
-    ],
-    "interval": 10000,
-    "blockConfirmation": 12,
-    "maxBlockRange": 5000
-  },
-  {
-    "chainId": 100000014,
-    "name": "Sonic",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 474266,
-    "providers": [
-      {
-        "provider": "https://rpc.soniclabs.com"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 24,
-    "maxBlockRange": 100
-  },
-  {
-    "chainId": 100000006,
-    "name": "Crossfi",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 961395,
-    "providers": [
-      {
-        "provider": "https://private-rpc.mainnet.ms/debridge/bea863cd-f4ec-43a7-ad41-0db2b57f011d"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 12,
-    "maxBlockRange": 5000
-  },
-  {
-    "chainId": 100000010,
-    "name": "Cronos zkEVM",
-    "debridgeAddr": "0xa706DaF168865b0b334ef8Ca2418F5AAC55a4b16",
-    "firstStartBlock": 1042707,
-    "providers": [
-      {
-        "provider": "https://mainnet.zkevm.cronos.org"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 12,
-    "maxBlockRange": 1000
-  },
-  {
-    "chainId": 100000017,
-    "name": "Abstract",
-    "debridgeAddr": "0xa706DaF168865b0b334ef8Ca2418F5AAC55a4b16",
-    "firstStartBlock": 239403,
-    "providers": [
-      {
-        "provider": "https://abstract-validator-rpc.debridge.finance",
-        "user": "***",
-        "password": "***"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 12,
-    "maxBlockRange": 5000
-  },
-  {
-    "chainId": 100000020,
-    "name": "Berachain",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 701819,
-    "providers": [
-      {
-        "provider": "https://berachain-validator-rpc.debridge.finance",
-        "user": "***",
-        "password": "***"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 24,
-    "maxBlockRange": 5000
-  },
-  {
     "chainId": 100000013,
     "name": "Story",
     "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
@@ -291,7 +156,7 @@
     ],
     "interval": 15000,
     "blockConfirmation": 9,
-    "maxBlockRange": 5000
+    "maxBlockRange": 50
   },
   {
     "chainId": 100000009,
@@ -308,60 +173,18 @@
     "maxBlockRange": 5000
   },
   {
-    "chainId": 100000021,
-    "name": "BOB",
+    "chainId": 100000019,
+    "name": "Cronos",
     "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 14720570,
+    "firstStartBlock": 42141500,
     "providers": [
       {
-        "provider": "https://rpc.gobob.xyz"
+        "provider": "TODO:Monad RPC"
       }
     ],
     "interval": 5000,
-    "blockConfirmation": 32,
-    "maxBlockRange": 5000
-  },
-  {
-    "chainId": 100000023,
-    "name": "Mantle",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 78041910,
-    "providers": [
-      {
-        "provider": "https://rpc.mantle.xyz"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 32,
-    "maxBlockRange": 5000
-  },
-  {
-    "chainId": 100000024,
-    "name": "Plume",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 59390,
-    "providers": [
-      {
-        "provider": "https://phoenix-rpc.plumenetwork.xyz"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 32,
-    "maxBlockRange": 5000
-  },
-  {
-    "chainId": 100000025,
-    "name": "Sophon",
-    "debridgeAddr": "0xa706DaF168865b0b334ef8Ca2418F5AAC55a4b16",
-    "firstStartBlock": 11674508,
-    "providers": [
-      {
-        "provider": "TODO:Sophon RPC"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 32,
-    "maxBlockRange": 5000
+    "blockConfirmation": 64,
+    "maxBlockRange": 2000
   },
   {
     "chainId": 100000027,
@@ -392,20 +215,6 @@
     "maxBlockRange": 5000
   },
   {
-    "chainId": 100000028,
-    "name": "Plasma",
-    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-    "firstStartBlock": 1100370,
-    "providers": [
-      {
-        "provider": "https://rpc.plasma.to"
-      }
-    ],
-    "interval": 5000,
-    "blockConfirmation": 32,
-    "maxBlockRange": 1000
-  },
-  {
     "chainId": 100000029,
     "name": "Injective",
     "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
@@ -432,6 +241,19 @@
     "interval": 5000,
     "blockConfirmation": 64,
     "maxBlockRange": 100
+  },
+  {
+    "chainId": 100000031,
+    "name": "MegaETH",
+    "debridgeAddr": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
+    "firstStartBlock": 1279660,
+    "providers": [
+      {
+         "provider": "TODO:MegaETH RPC"
+      }
+    ],
+    "interval": 5000,
+    "blockConfirmation": 64,
+    "maxBlockRange": 5000
   }
-
 ]

--- a/config/chains_config_default.json
+++ b/config/chains_config_default.json
@@ -25,7 +25,7 @@
     "firstStartBlock": 12861230,
     "provider": "https://bsc-dataseed1.defibit.io/",
     "interval": 10000,
-    "blockConfirmation": 12,
+    "blockConfirmation": 48,
     "maxBlockRange": 5000
   },
   {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - debridge-node-network
     logging: *default-logging
   solana-grpc-service:
-    image: debridgefinance/debridge-solana-events-reader-grpc-server:v0.9.5@sha256:f453d4f03bffce99b3373f829539c494ece4953f4492b12284cf628222b5e225
+    image: debridgefinance/debridge-solana-events-reader-grpc-server:v0.9.8-prod@sha256:5a8e04b2f3e19a5ba0636eef1b73d3367b1efea4fbfceff91b3d69811c799e55
     container_name: solana-grpc-service${DOCKER_ID}
     restart: unless-stopped
     networks:
@@ -39,7 +39,7 @@ services:
       - DEBRIDGE_EVENTS_API_SENTRY_URL=${DEBRIDGE_EVENTS_SENTRY_DSN}
     logging: *default-logging
   solana-events-reader:
-    image: debridgefinance/debridge-solana-events-reader:v0.9.5@sha256:f0ce004431c7d7d6d9c348babbb7d1574a18eaf15a86219e049763a4c450f71c
+    image: debridgefinance/debridge-solana-events-reader:v0.9.8-prod@sha256:7add18f998327c2f1676832bbacc472cb5e3b64e118ffbbb467b23c4e3d4eaa3
     hostname: events-reader
     restart: unless-stopped
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     logging: *default-logging
 
   debridge-node:
-    image: debridgefinance/debridge-node:2.8.1@sha256:f9a25f6224831e30114dfdd309b5e942ea8f36bdb3f40cc676eb07d9665dc509
+    image: debridgefinance/debridge-node:2.8.4@sha256:39a50346d4603713c404807b55da036aa5c27867409c6f601e2b410cda8d10a1
     container_name: debridge-node${DOCKER_ID}
     restart: unless-stopped
     secrets:


### PR DESCRIPTION
## Release 2.8.4

### Docker image updates
- `debridge-node`: `2.8.1` → `2.8.4`
- `debridge-solana-events-reader`: `v0.9.5` → `v0.9.8-prod`
- `debridge-solana-events-reader-grpc-server`: `v0.9.5` → `v0.9.8-prod`

### Removed obsolete chains

1. Fantom
2. NEON
3. Gnosis
4. Metis
5. Sonic
6. Crossfi
7. Cronos zkEVM
8. Abstract
9. Berachain
10. BOB
11. Mantle
12. Plume
13. Sophon
14. Plasma

### Added new chains
- **Cronos** (chainId: `100000019`) — blockConfirmation: 64, maxBlockRange: 2000
- **MegaETH** (chainId: `100000031`) — blockConfirmation: 64, maxBlockRange: 5000

### Chain parameter changes
- **BSC**: `blockConfirmation` 12 → 48
- **Zilliqa EVM**: `maxBlockRange` 5000 → 50